### PR TITLE
Remove useless conditional

### DIFF
--- a/str.c
+++ b/str.c
@@ -57,8 +57,7 @@ void* mempcpy(void* dest, const void* src, const size_t n)
 static inline
 void str_mem_free(void* p)
 {
-	if(p)
-		free(p);
+	free(p);
 }
 
 // string deallocation


### PR DESCRIPTION
As per the free(3) manual page:

	The free() function deallocates the memory allocation pointed to by
	ptr.  If ptr is a NULL pointer, no operation is performed.

Checking to see if ‘p’ is not NULL before freeing is useless, since
‘free(NULL)’ is defined to be a no-op.
